### PR TITLE
Remove DSRV validator endpoints fron testnet

### DIFF
--- a/config/prod/endpoints.json
+++ b/config/prod/endpoints.json
@@ -19,7 +19,6 @@
             ],
             "validators":[
                "https://dydx-testnet.nodefleet.org",
-               "https://dydx-testnet-archive.allthatnode.com:26657/XZvMM41hESf8PJrEQiTzbCOMVyFca79R",
                "https://test-dydx.kingnodes.com/"
             ],
             "0xsquid":"https://squid-api-git-main-cosmos-testnet-0xsquid.vercel.app",

--- a/config/staging/dev_endpoints.json
+++ b/config/staging/dev_endpoints.json
@@ -224,7 +224,6 @@
             ],
             "validators":[
                "https://dydx-testnet.nodefleet.org",
-               "https://dydx-testnet-archive.allthatnode.com:26657/XZvMM41hESf8PJrEQiTzbCOMVyFca79R",
                "https://test-dydx.kingnodes.com/"
             ],
             "0xsquid":"https://squid-api-git-main-cosmos-testnet-0xsquid.vercel.app",

--- a/config/staging/endpoints.json
+++ b/config/staging/endpoints.json
@@ -166,7 +166,6 @@
              ],
              "validators":[
                 "https://dydx-testnet.nodefleet.org",
-                "https://dydx-testnet-archive.allthatnode.com:26657/XZvMM41hESf8PJrEQiTzbCOMVyFca79R",
                 "https://test-dydx.kingnodes.com/"
              ],
              "0xsquid":"https://squid-api-git-main-cosmos-testnet-0xsquid.vercel.app",


### PR DESCRIPTION
DSRV is having a number or partial outages / issues. To reduce confusion in debugging issues we're removing them from the list of potential validators for testnet. We want to keep the option to explicitly choose them but remove them from the list of validators that are automatically selected from.