### PR TITLE
MOB-417 : add settings control to turn in-app notifications on/off completely

### DIFF
--- a/config/localizations_native/en/app.json
+++ b/config/localizations_native/en/app.json
@@ -359,6 +359,8 @@
       "NO_GAS_TITLE": "Insufficent wallet balance to cover gas fee",
       "NO_GAS_BODY": "Please first make a small deposit to your dYdX account to refill wallet.",
       "THEME": "Theme",
+      "NOTIFICATIONS": "Notifications",
+      "DISPLAY_IN_APP_NOTIFICATIONS": "Display In-App Notifications",
       "DIRECTION_COLOR_PREFERENCE": "Color Preference",
       "DARK": "Dark",
       "CLASSIC_DARK": "Classic Dark",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-localization",
-  "version": "1.1.53",
+  "version": "1.1.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-localization",
-      "version": "1.1.53",
+      "version": "1.1.54",
       "license": "AGPL-3.0",
       "devDependencies": {
         "@types/node": "^20.1.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-localization",
-  "version": "1.1.53",
+  "version": "1.1.54",
   "description": "v4 localization",
   "main": "index.ts",
   "scripts": {


### PR DESCRIPTION
[MOB-417 : add settings control to turn in-app notifications on/off completely](https://linear.app/dydx/issue/MOB-417/add-settings-control-to-turn-in-app-notifications-onoff-completely)

see [iOS PR](https://github.com/dydxprotocol/v4-native-ios/pull/124)