### PR TITLE
fix terms of use links

### DIFF
--- a/config/localization/en/app.json
+++ b/config/localization/en/app.json
@@ -245,7 +245,7 @@
       "PASTE": "Paste",
       "PENDING_REWARDS": "Pending Rewards",
       "PENDING": "Pending",
-      "PERPETUALS_UNAVAILABLE_IN_US": "Perpetuals are not available to people or companies who are residents of, or are located, incorporated or have a registered agent in, the United States or a restricted territory. More details can be found in our Terms of Use ",
+      "PERPETUALS_UNAVAILABLE_IN_US": "Perpetuals are not available to people or companies who are residents of, or are located, incorporated or have a registered agent in, the United States or a restricted territory. More details can be found in our {TERMS_OF_USE_LINK}.",
       "PERPETUALS": "Perpetuals",
       "PNL": "P&L",
       "POSITION": "Position",
@@ -2004,7 +2004,7 @@
     "COMPLIANCE": {
       "CLOSE_ONLY_MESSAGE": "Because you appear to be a resident of, or trading from, a jurisdiction that violates our terms of use, or have engaged in activity that violates our terms of use, you have been blocked. You have until {DATE} to withdraw your funds before your access to the frontend is blocked. If you believe there has been an error, please email {EMAIL}.",
       "PERMANENTLY_BLOCKED_MESSAGE": "Because you appear to be a resident of, or trading from, a jurisdiction that violates our terms of use and previously have been given an opportunity to redress circumstances that led to restrictions on your account, you have been permanently blocked. If you believe there has been an error, please email {EMAIL}.",
-      "BLOCKED_MESSAGE": "Perpetuals are not available to any persons who are residents of, are located or incorporated in, or have a registered agent in a blocked country or a restricted territory. More details can be found in our Terms of Use {LINK}."
+      "BLOCKED_MESSAGE": "Perpetuals are not available to any persons who are residents of, are located or incorporated in, or have a registered agent in a blocked country or a restricted territory. More details can be found in our {TERMS_OF_USE_LINK}."
     }
   },
   "TOKEN_MIGRATION": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-localization",
-  "version": "1.1.136",
+  "version": "1.1.137",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-localization",
-      "version": "1.1.136",
+      "version": "1.1.137",
       "license": "AGPL-3.0",
       "devDependencies": {
         "@types/node": "^20.1.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-localization",
-  "version": "1.1.136",
+  "version": "1.1.137",
   "description": "v4 localization",
   "main": "index.ts",
   "scripts": {


### PR DESCRIPTION
something small I noticed where we weren't linking the whole terms of use links in app because translations were slightly off. would ideally like to fix so we can have consistent styling