### PR TITLE
feat: new withdraw copy

### DIFF
--- a/config/localization/en/app.json
+++ b/config/localization/en/app.json
@@ -985,7 +985,7 @@
       "FAST": "Fast",
       "FAST_WITHDRAW_CONFIRMATION": "A fee of {FEE} will be collected for this fast withdraw. Your funds will be sent immediately and will appear in your wallet once the withdraw transaction has confirmed.",
       "LOWEST_FEES_HIGHLIGHT_TEXT": "lowest fees",
-      "LOWEST_FEE_WITHDRAWALS": "USDC withdrawals to {LOWEST_FEE_TOKENS_TOOLTIP} have the lowest fees. Other withdrawals may have additional third-party fees.",
+      "LOWEST_FEE_WITHDRAWALS": "USDC withdrawals to {LOWEST_FEE_TOKENS_TOOLTIP} have the lowest fees. Other withdrawals methods (e.g., assets on Ethereum) may have higher third-party fees.",
       "LOWEST_FEES_WITH_USDC": "{LOWEST_FEES_HIGHLIGHT_TEXT} with USDC",
       "MAGIC_LINK_WITHDRAW_DESCRIPTION": "To access the withdrawn funds and reuse your Magic wallet outside of dYdX, you must export your wallet to another wallet provider.",
       "SELECT_CHAINS": "select chains",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-localization",
-  "version": "1.1.145",
+  "version": "1.1.146",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-localization",
-      "version": "1.1.145",
+      "version": "1.1.146",
       "license": "AGPL-3.0",
       "devDependencies": {
         "@types/node": "^20.1.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-localization",
-  "version": "1.1.145",
+  "version": "1.1.146",
   "description": "v4 localization",
   "main": "index.ts",
   "scripts": {

--- a/scripts/generated/app.ts
+++ b/scripts/generated/app.ts
@@ -1,6 +1,6 @@
 // !! GENERATED FILE - DO NOT EDIT
 
-// Generated from ../config/localization/en/app.json using ./codegen_localization_app.swift
+// Generated from ../config/localization/en/app.json using codegen_localization_app.swift
 
 export const APP_STRING_KEYS = {
 


### PR DESCRIPTION
Notates that ethereum is no longer a lowest cost chain for withdrawals despite its usdc having cctp status
<img width="521" alt="Screenshot 2024-07-08 at 1 37 17 PM" src="https://github.com/dydxprotocol/v4-localization/assets/37092291/9d1915b5-a10b-40c1-9ffe-136169b2388e">
<img width="488" alt="Screenshot 2024-07-08 at 1 38 08 PM" src="https://github.com/dydxprotocol/v4-localization/assets/37092291/299fc9de-e388-46e9-9618-ccba097fd607">



Keeps deposit dialog the same 
<img width="545" alt="Screenshot 2024-07-08 at 1 37 50 PM" src="https://github.com/dydxprotocol/v4-localization/assets/37092291/2dce50b4-8095-4506-8348-79d36608b084">
<img width="520" alt="Screenshot 2024-07-08 at 1 37 58 PM" src="https://github.com/dydxprotocol/v4-localization/assets/37092291/8d608370-3a0a-4b65-8864-20bce7065f33">
